### PR TITLE
Make spacy max_length configurable through the environment

### DIFF
--- a/displacy/app.py
+++ b/displacy/app.py
@@ -1,6 +1,7 @@
 # coding: utf8
 from __future__ import unicode_literals
 import threading
+import os
 
 import hug
 from hug_middleware_cors import CORSMiddleware
@@ -13,17 +14,20 @@ lock = threading.Lock()
 
 def load_model_once(model):
 
-    if not model in MODELS:
-        lock.acquire()
-        try:
-            if not model in MODELS:
-                        print("Loading model {}".format(model))
-                        MODELS[model] = spacy.load(model)
-                        print("Loaded model {}".format(model))
-            lock.release()
-        except:
-            lock.release()
-            raise
+    if model not in MODELS:
+        with lock:
+            if model not in MODELS:
+                print("Loading model {}".format(model))
+
+                nlp = spacy.load(model)
+
+                spacy_max_length = os.getenv('SPACY_MAX_LENGTH')
+                if spacy_max_length is not None:
+                    nlp.max_length = int(spacy_max_length)
+
+                MODELS[model] = nlp
+
+                print("Loaded model {}".format(model))
 
     return MODELS[model]
 

--- a/matcher/app.py
+++ b/matcher/app.py
@@ -1,5 +1,6 @@
 # coding: utf8
 from __future__ import unicode_literals
+import os
 
 import hug
 from hug_middleware_cors import CORSMiddleware
@@ -7,7 +8,17 @@ import spacy
 from spacy.matcher import Matcher
 
 
-MODELS = {"en_core_web_sm": spacy.load("en_core_web_sm")}
+def load_spacy_model(model):
+    nlp = spacy.load(model)
+
+    spacy_max_length = os.getenv('SPACY_MAX_LENGTH')
+    if spacy_max_length is not None:
+        nlp.max_length = int(spacy_max_length)
+
+    return nlp
+
+
+MODELS = {"en_core_web_sm": load_spacy_model("en_core_web_sm")}
 
 
 def get_model_desc(nlp, model_name):


### PR DESCRIPTION
Setting the limit to a sufficiently high value prevents errors like:
[E088] Text of length 1087423 exceeds maximum of 1000000.
(at the cost of using more memory, obviously).

Also made the code a bit more Pythonic.